### PR TITLE
Update to 1.11 textures

### DIFF
--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -34,7 +34,7 @@ import itsdangerous
 # useful constants
 DEFAULT_REPOSITORY = "https://github.com/overviewer/Minecraft-Overviewer"
 EXMAPLE_REPOSITORY = "https://github.com/overviewer/Minecraft-Overviewer-Addons"
-DEFAULT_CLIENT_JAR_VER = "1.10"
+DEFAULT_CLIENT_JAR_VER = "1.11"
 UPLOAD_DEST = "/data/buildbot/uploads"
 UPLOAD_URL = "http://overviewer.org/builds"
 DEBIAN_REPO = "/data/buildbot/repos/debian"


### PR DESCRIPTION
Update buildbot to use 1.11 textures for the render. Fixes some spam about failures in #overviewer.