### PR TITLE
avatar: cache skin URLs and UUID resolution

### DIFF
--- a/flask/overviewer/avatar.py
+++ b/flask/overviewer/avatar.py
@@ -9,11 +9,13 @@ from .cache import cache
 
 avatar = Blueprint('avatar', __name__)
 
+@cache.memoize(3600)
 def get_uuid(username):
     response = requests.get("https://api.mojang.com/users/profiles/minecraft/{}".format(username))
     if response.status_code == 200:
         return json.loads(response.content.decode('utf-8', 'ignore'))["id"]
 
+@cache.memoize(3600)
 def get_skin_url(uuid):
     response = requests.get("https://sessionserver.mojang.com/session/minecraft/profile/{}".format(uuid))
     if response.status_code == 200:
@@ -28,7 +30,8 @@ def get_skin_url(uuid):
             return ""
 
 def get_from_minecraft(player="__default_img__"):
-    "Gets an image from minecraft. Returns a PIL Image object. never caches"
+    """Gets an image from minecraft. Returns a PIL Image object. Never caches,
+    but the skin URL and the UUID resolution may be cached."""
 
     defaultSkinURL = "http://assets.mojang.com/SkinTemplates/steve.png"
     skinURL = defaultSkinURL


### PR DESCRIPTION
Mojang rate-limits these pretty hard (for good reason!), so requesting `/head` and then immediately `/bighead` would make the Mojang API ratelimit us immediately on those two endpoints.

We might want to think about what is being cached more in the future.