### PR TITLE
avatar: don't use flask's slash redirect code

### DIFF
--- a/flask/overviewer/avatar.py
+++ b/flask/overviewer/avatar.py
@@ -100,6 +100,7 @@ def get_avatar(kind, username):
         abort(503)
 
 @avatar.route('/<username>/')
+@avatar.route('/<username>')
 @cache.cached(86400)
 def default(username):
     return get_avatar('av', username)


### PR DESCRIPTION
With a lack of a trailing slash, Flask would redirect HTTPS URLs to non-HTTPS URLs because HTTPS is handled by nginx.

Instead of doing that, just serve the thing too.