### PR TITLE
Add textures endpoint to fetch client jar

### DIFF
--- a/flask/overviewer/textures.py
+++ b/flask/overviewer/textures.py
@@ -1,0 +1,42 @@
+from flask import Blueprint, abort, redirect
+import requests
+
+from .cache import cache
+
+
+textures = Blueprint('textures', __name__)
+
+
+@cache.memoize(1200)
+def get_version_manifest():
+    M_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json"
+    manifest = requests.get(M_URL).json()
+    assert("latest" in manifest)
+    assert("versions" in manifest)
+    return manifest
+
+
+@cache.memoize(3600)
+def get_client_manifest(url):
+    manifest = requests.get(url).json()
+    assert("downloads" in manifest)
+    assert("client" in manifest["downloads"])
+    return manifest
+
+
+@textures.route('/<version>')
+def get_textures(version):
+    ver = version
+    m = get_version_manifest()
+    c_m_url = ""
+
+    if version == "latest":
+        ver = m["latest"]["release"]
+    for client in m["versions"]:
+        if client["id"] == ver:
+            c_m_url = client["url"]
+            break
+    else:
+        return abort(404)
+    client_m = get_client_manifest(c_m_url)
+    return redirect(client_m["downloads"]["client"]["url"])

--- a/flask/overviewer/views.py
+++ b/flask/overviewer/views.py
@@ -7,9 +7,11 @@ from .blog import *
 from .avatar import *
 from .uploader import *
 from .downloads import *
+from .textures import *
 
 app.register_blueprint(avatar, url_prefix='/avatar')
 app.register_blueprint(uploader, url_prefix='/uploader')
+app.register_blueprint(textures, url_prefix='/textures')
 
 @app.route('/')
 def index():


### PR DESCRIPTION
Mojang's new launcher manifest stuff made it impossible to fetch a specific client jar with a single wget.

This commit adds a new endpoint to the overviewer flask app, called `textures`, which HTTP redirects to the client.jar of a version of one's choosing, or the latest release one with "latest".

E.g.:
 - /textures/latest -> 302 to latest client.jar
 - /textures/1.13.2 -> 302 to 1.13.2 client.jar

 The launcher manifest is cached for 20 minutes, the client manifests are cached for 1 hour.