### PR TITLE
buildbot: pin windows numpy to 1.16.4

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -440,7 +440,7 @@ def windows(arch):
             return Interpolate(path)
         return path
     del pythonexe
-    yield ShellCommand(command=[script("pip"), "install", "numpy", "Pillow==5.1.0", "pyinstaller", "sphinx"], name="dependencies")
+    yield ShellCommand(command=[script("pip"), "install", "numpy==1.16.4", "Pillow==5.1.0", "pyinstaller", "sphinx"], name="dependencies")
 
     yield checkout(python=script("python"))
     yield FileDownload(mastersrc="pyinstaller-windows.spec", workerdest="overviewer.spec", name="transfer spec file")


### PR DESCRIPTION
NumPy 1.17.0 has an issue in the random module that prevents Overviewer from starting on Windows in pyinstaller generated packages. For now, let's pin it to 1.16.4 until either they fix it or we can do some sleuthing as to why it is broken.