### PR TITLE
buildbot: change numpy requirement to >=1.17.1

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -440,7 +440,7 @@ def windows(arch):
             return Interpolate(path)
         return path
     del pythonexe
-    yield ShellCommand(command=[script("pip"), "install", "numpy==1.16.4", "Pillow==5.1.0", "pyinstaller", "sphinx"], name="dependencies")
+    yield ShellCommand(command=[script("pip"), "install", "numpy>=1.17.1", "Pillow==5.1.0", "pyinstaller", "sphinx"], name="dependencies")
 
     yield checkout(python=script("python"))
     yield FileDownload(mastersrc="pyinstaller-windows.spec", workerdest="overviewer.spec", name="transfer spec file")


### PR DESCRIPTION
The pyinstaller thing is fixed now.