### PR TITLE
Fix rendering, db init, example

### DIFF
--- a/buildbot/master/master.cfg
+++ b/buildbot/master/master.cfg
@@ -49,7 +49,7 @@ class BaseConfig:
     BUILDBOT_SECRET = os.environ['BUILDBOT_SECRET']
     FLASK_SECRET = os.environ['FLASK_SECRET']
 
-    DEFAULT_CLIENT_JAR_VER = "1.14"
+    DEFAULT_CLIENT_JAR_VER = "1.15"
 
     ALL_BUILDERS = ['src', 'render', 'win32',
                     'win64', 'deb32', 'deb64', 'centos7-64']
@@ -646,4 +646,4 @@ def render():
         def has_val(name, val):
             return step.build.getProperty(name) in [None, val]
         return step.build.getProperty('release_build') and has_val('rendermode', 'smooth_lighting') and has_val('client_jar_version', config.DEFAULT_CLIENT_JAR_VER) and has_val('exmaple_commit', 'master')
-    yield MasterShellCommand(command=Interpolate("rm -f " + EXMAPLE_PATH + " && ln -s %(prop:render_upload)s " + EXMAPLE_PATH), name="link exmaple", doStepIf=is_exmaple, locks=[exmaple_lock.access('exclusive')], description="linking exmaple", descriptionDone="linked exmaple")
+    yield MasterShellCommand(command=Interpolate("rm -f " + EXMAPLE_PATH.as_posix() + " && ln -s %(prop:render_upload)s " + EXMAPLE_PATH.as_posix()), name="link exmaple", doStepIf=is_exmaple, locks=[exmaple_lock.access('exclusive')], description="linking exmaple", descriptionDone="linked exmaple")

--- a/postgres/init-database.sh
+++ b/postgres/init-database.sh
@@ -1,7 +1,7 @@
-gosu postgres postgres --single -jE <<EOF
+psql <<EOF
 CREATE DATABASE "flask" WITH OWNER="postgres" TEMPLATE=template0 ENCODING='UTF8';
 EOF
 
-gosu postgres postgres --single -jE <<EOF
+psql <<EOF
 CREATE DATABASE "bbmaster" WITH OWNER="postgres" TEMPLATE=template0 ENCODING='UTF8';
 EOF


### PR DESCRIPTION
A bunch of small fixes:
- update client jar version to 1.15
- the newer version of the postgres container no longer uses
  gosu, you can just invoke the commands directly
- link example correctly, because adding a string and a Path() is
  not a thing you can do but somehow nothing ever yelled at us