### PR TITLE
debian/control: Depend on the correct version of python3

### DIFF
--- a/buildbot/repos/debian/control/control
+++ b/buildbot/repos/debian/control/control
@@ -9,5 +9,5 @@ Package: minecraft-overviewer
 Architecture: any
 Homepage: http://overviewer.org/
 X-Python3-Version: >= 3.4 
-Depends: ${misc:Depends}, python3 (>= 3.4), python3-pil, python3-numpy, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${python3:Depends}, python3-pil, python3-numpy, ${shlibs:Depends}
 Description: Generates large resolution images of a Minecraft map.


### PR DESCRIPTION
Use the python3 dependency determined by dh-python. The current package is installable but not usable on systems with a newer release of python3 than on the build system (see overviewer/Minecraft-Overviewer#1595).