### PR TITLE
Make sure pip is at the latest version

### DIFF
--- a/buildbot/docker-builders/centos7-64/Dockerfile
+++ b/buildbot/docker-builders/centos7-64/Dockerfile
@@ -8,6 +8,7 @@ RUN yum --exclude=iputils update -y && yum install -y \
 RUN ln -sf /usr/bin/python3.6 /usr/bin/python3 \
     && ln -sf /usr/bin/pip3.6 /usr/bin/pip3
 
+RUN python3 -m pip install -U pip==20.3.4
 RUN python3 -m pip install "buildbot[bundle]" sphinx
 
 ENV WORKER_NAME diax-centos7-64

--- a/buildbot/docker-builders/stretch-32/Dockerfile
+++ b/buildbot/docker-builders/stretch-32/Dockerfile
@@ -5,6 +5,7 @@ jq git curl wget devscripts \
 python3.5 python3-all-dev python3-numpy python3-pil python3-pip \
 build-essential libssl-dev libffi-dev
 
+RUN python3 -m pip install -U pip==20.3.4
 RUN python3 -m pip install "buildbot[bundle]==2.*"
 
 ENV WORKER_NAME diax-stretch-32

--- a/buildbot/docker-builders/stretch-64/Dockerfile
+++ b/buildbot/docker-builders/stretch-64/Dockerfile
@@ -5,6 +5,7 @@ jq git curl wget devscripts \
 python3.5 python3-all-dev python3-numpy python3-pil python3-pip \
 build-essential libssl-dev libffi-dev
 
+RUN python3 -m pip install -U pip==20.3.4
 RUN python3 -m pip install "buildbot[bundle]==2.*"
 
 ENV WORKER_NAME diax-stretch-64


### PR DESCRIPTION
This was required in order to successfully build the stretch-32 and
centos7-64 images.   stretch-64 didn't need it, but keeping that
Dockerfile consistent with the others seemed like the right thing to do.